### PR TITLE
Yubikey works

### DIFF
--- a/app/src/main/java/org/cgutman/usbip/service/UsbIpService.java
+++ b/app/src/main/java/org/cgutman/usbip/service/UsbIpService.java
@@ -558,10 +558,11 @@ public class UsbIpService extends Service implements UsbRequestHandler {
 			context.activeMessages.add(msg);
 			
 			int res;
-			
+			boolean isDeviceToHost = (requestType & 0x80) != 0;
+
 			do {
 				res = XferUtils.doControlTransfer(devConn, requestType, request, value, index,
-					(requestType & 0x80) != 0 ? reply.inData : msg.outData, length, 1000);
+					isDeviceToHost ? reply.inData : msg.outData, length, 1000);
 				
 				if (context.requestPool.isShutdown()) {
 					// Bail if the queue is being torn down
@@ -578,7 +579,7 @@ public class UsbIpService extends Service implements UsbRequestHandler {
 				reply.status = res;
 			}
 			else {
-				reply.actualLength = res;
+				reply.actualLength = isDeviceToHost ? res : 0;
 				reply.status = ProtoDefs.ST_OK;
 			}
 			

--- a/app/src/main/java/org/cgutman/usbip/usb/XferUtils.java
+++ b/app/src/main/java/org/cgutman/usbip/usb/XferUtils.java
@@ -52,9 +52,10 @@ public class XferUtils {
 			
 			bytesTransferred += res;
 			
-			if (res < endpoint.getMaxPacketSize()) {
+			if (res != endpoint.getMaxPacketSize()) {
 				// A packet less than the maximum size for this endpoint
 				// indicates the transfer has ended
+				// For some devices (yubikey) the res is greater than max packet size
 				break;
 			}
 		}


### PR DESCRIPTION
Here are 2 fixes which make it possible to use yubikey remotely.
1. First fix prevents from reporting incoming packet size as outgoing packet and is probably as universal as I can imagine.
2. The second one is a bit tricky and I am not convinced that this is the end of the story.
GPT suggested that detecting the end of bulk transfer is not universal condition and can depend on a device.
One of the logic listed was exactly what the original code did. If api gives back less than what max packet size is, that is the end of transmission. However, for yubikey it is actually more than max packet size. This hints at possibility that android api reports wrong max size or android api reassemble packets before giving it back or reported max size is wrong or something else. For now this is the fix. I will keep digging - have to look at android api source and probably check what yubikey tools are doing.